### PR TITLE
Add genre search

### DIFF
--- a/app/Http/Controllers/SpotifyController.php
+++ b/app/Http/Controllers/SpotifyController.php
@@ -9,11 +9,13 @@ use Illuminate\Support\Facades\Http;
 
 class SpotifyController extends Controller
 {
-    public function index() {
-        
+    public function index()
+    {
+
     }
 
-    public function disconnect() {
+    public function disconnect()
+    {
         SpotifyUserData::where('user_id', Auth::id())->delete();
         return redirect('/dashboard');
     }
@@ -72,7 +74,7 @@ class SpotifyController extends Controller
     {
         $clientId = config('services.spotify.client_id');
         $clientSecret = config('services.spotify.client_secret');
-        
+
         // Spotify's token endpoint for refreshing tokens.
         $url = 'https://accounts.spotify.com/api/token';
 
@@ -83,14 +85,14 @@ class SpotifyController extends Controller
         $response = Http::asForm()->withHeaders([
             'Authorization' => 'Basic ' . $authHeader,
         ])->post($url, [
-            'grant_type'    => 'refresh_token',
-            'refresh_token' => $refreshToken,
-        ]);
+                    'grant_type' => 'refresh_token',
+                    'refresh_token' => $refreshToken,
+                ]);
 
         // Check if the request was successful.
         if ($response->successful()) {
             $data = $response->json();
-            
+
             SpotifyUserData::where('spotify_refresh_token', $refreshToken)
                 ->update([
                     'spotify_token' => $data['access_token'],
@@ -102,6 +104,53 @@ class SpotifyController extends Controller
         // Log or handle the error as needed.
         \Log::error('Spotify token refresh failed: ' . $response->body());
         return null;
+    }
+
+    public function randomWithGenre($genre)
+    {
+        $accessToken = SpotifyUserData::where('user_id', Auth::id())->value('spotify_token');
+        if (!$accessToken) {
+            return response()->json(['error' => 'Spotify access token not configured.'], 500);
+        }
+
+        // Generate a random letter (a-z) for our search query
+        $randomLetter = chr(rand(97, 122)); // ASCII 97 ('a') to 122 ('z')
+
+        // Define the Spotify search endpoint and query parameters
+        $endpoint = 'https://api.spotify.com/v1/search';
+        $params = [
+            'q' => "genre:$genre $randomLetter",
+            'type' => 'track',
+            'limit' => 50,
+        ];
+
+        // Make the request using Laravel's HTTP client with the Bearer token
+        $response = Http::withToken($accessToken)->get($endpoint, $params);
+
+        // Check if the request failed and return an error response if so
+        if ($response->failed()) {
+            return response()->json(['error' => 'Spotify API request failed.'], $response->status());
+        }
+
+        $data = $response->json();
+
+        // Check if tracks are available in the response
+        if (!isset($data['tracks']['items']) || empty($data['tracks']['items'])) {
+            return response()->json(['error' => 'No tracks found for the search query.'], 404);
+        }
+
+        // Randomly select one track from the list
+        $tracks = $data['tracks']['items'];
+        $randomTrack = $tracks[array_rand($tracks)];
+
+        // Get the names of the artists
+        $artistNames = collect($randomTrack['artists'])->pluck('name')->toArray();
+        // Return the track details as JSON
+        return response()->json([
+            'track' => $randomTrack['name'],
+            'artists' => implode(', ', $artistNames),
+            'url' => $randomTrack['external_urls']['spotify']
+        ]);
     }
 
     /**

--- a/resources/js/Pages/Dashboard.tsx
+++ b/resources/js/Pages/Dashboard.tsx
@@ -1,9 +1,18 @@
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout';
 import { PageProps } from '@/types';
+import { api } from '@/utils';
 import { Head, Link } from '@inertiajs/react';
 import { Spotify, Trash, TrashFill } from 'react-bootstrap-icons';
 
 export default function Dashboard({ auth }: PageProps) {
+
+    const getRandomTrack = () => {
+        api.get('/spotify/random/jazz').then(response => {
+            if (response.status === 200) {
+                console.log(response.data);
+            }
+        });
+    };
 
     return (
         <AuthenticatedLayout
@@ -15,6 +24,7 @@ export default function Dashboard({ auth }: PageProps) {
         >
             <Head title="Dashboard" />
             <div className="py-12">
+                <button onClick={getRandomTrack}>Get random track</button>
                 <div className="mx-auto max-w-7xl sm:px-6 lg:px-8">
                     <div className="overflow-hidden bg-white shadow-sm sm:rounded-lg dark:bg-gray-800">
                         <div className="p-6 text-gray-900 dark:text-gray-100">

--- a/resources/js/Pages/player/player.tsx
+++ b/resources/js/Pages/player/player.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import { atom, useAtom } from 'jotai';
 import Authenticated from '@/Layouts/AuthenticatedLayout';
 import { PageProps } from '@/types';
-import { api, currentStateAtom, currentTrackAtom, deviceIdAtom, isActiveAtom, isPausedAtom, playerAtom, volumeAtom } from '@/utils';
+import { api, currentStateAtom, currentTrackAtom, deviceIdAtom, isActiveAtom, isPausedAtom, isReadyAtom, playerAtom, volumeAtom } from '@/utils';
 import 'https://sdk.scdn.co/spotify-player.js';
 import { PauseFill, PlayFill } from 'react-bootstrap-icons';
 import { toast } from 'react-toastify';
@@ -23,7 +23,7 @@ export function Player({ auth }: { auth: PageProps['auth'] }) {
     const [deviceId, setDeviceId] = useAtom(deviceIdAtom);
     const [volume, setVolume] = useAtom(volumeAtom);
     const [currentState, setCurrentState] = useAtom(currentStateAtom);
-    const [isReady, setReady] = useState(false);
+    const [isReady, setReady] = useAtom(isReadyAtom);
 
     useEffect(() => {
         // Check if the Spotify Web Playback SDK script is already loaded

--- a/resources/js/utils.ts
+++ b/resources/js/utils.ts
@@ -19,3 +19,4 @@ export const currentTrackAtom = atom<Spotify.Track | null>(null);
 export const deviceIdAtom = atom<string | null>(null);
 export const volumeAtom = atomWithStorage('volume', 0.5);
 export const currentStateAtom = atom<Spotify.PlaybackState | null>(null);
+export const isReadyAtom = atom(false);

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,4 +9,5 @@ use Inertia\Inertia;
 
 
 Route::get('/spotify/random', [SpotifyController::class, 'random'])->middleware('web');
+Route::get('/spotify/random/{genre}', [SpotifyController::class, 'randomWithGenre'])->middleware('web');
 Route::get('/spotify/disconnect', [SpotifyController::class, 'disconnect'])->middleware('web')->name('spotify.disconnect');


### PR DESCRIPTION
This pull request includes several changes to the `SpotifyController` and related frontend components to add a new feature for fetching random tracks by genre from Spotify. The most important changes include adding a new method to the `SpotifyController`, updating the `Dashboard` component to use this new feature, and modifying the state management in the player component.

Backend changes:

* [`app/Http/Controllers/SpotifyController.php`](diffhunk://#diff-262a8cbf10d16bc5bbf79870e09525c67788fec0b13905dbeaf2a70f8fc8339dR109-R155): Added a new method `randomWithGenre` to fetch a random track by genre from the Spotify API.
* [`routes/api.php`](diffhunk://#diff-0e4323e6a03c91c9c8dc88afef15fdad09636468c0ac3550f497618372788b6dR12): Added a new route for the `randomWithGenre` method in the `SpotifyController`.

Frontend changes:

* [`resources/js/Pages/Dashboard.tsx`](diffhunk://#diff-530c59fd9356425e637e29abd1d77a1cc60c8649be86e06a33d82e7c176814efR3-R16): Added a new function `getRandomTrack` to call the new API endpoint and display a button to trigger this function. [[1]](diffhunk://#diff-530c59fd9356425e637e29abd1d77a1cc60c8649be86e06a33d82e7c176814efR3-R16) [[2]](diffhunk://#diff-530c59fd9356425e637e29abd1d77a1cc60c8649be86e06a33d82e7c176814efR27)
* [`resources/js/Pages/player/player.tsx`](diffhunk://#diff-86463fea50b4683e5e96015ead0097077410a821f9f4f4fd94583fdd58a53592L5-R5): Updated the player component to use a new atom `isReadyAtom` for managing the player's ready state. [[1]](diffhunk://#diff-86463fea50b4683e5e96015ead0097077410a821f9f4f4fd94583fdd58a53592L5-R5) [[2]](diffhunk://#diff-86463fea50b4683e5e96015ead0097077410a821f9f4f4fd94583fdd58a53592L26-R26)
* [`resources/js/utils.ts`](diffhunk://#diff-b3e194c539d85117c8d58dafce19b48a1af3aec17b4a4bc890ab3385488a5bfdR22): Added a new atom `isReadyAtom` for managing the player's ready state.