### PR TITLE
Add genre selection dialog and update random track retrieval by genre

### DIFF
--- a/app/Http/Controllers/SpotifyController.php
+++ b/app/Http/Controllers/SpotifyController.php
@@ -142,7 +142,7 @@ class SpotifyController extends Controller
 
         // Randomly select one track from the list
         $tracks = $data['tracks']['items'];
-        $randomTrack = $tracks[array_rand($tracks)];
+        $randomTrack = $tracks[array_rand($tracks)];    
 
         // Get the names of the artists
         $artistNames = collect($randomTrack['artists'])->pluck('name')->toArray();
@@ -150,7 +150,7 @@ class SpotifyController extends Controller
         return response()->json([
             'track' => $randomTrack['name'],
             'artists' => implode(', ', $artistNames),
-            'url' => $randomTrack['external_urls']['spotify']
+            'url' => $randomTrack['uri']
         ]);
     }
 

--- a/resources/js/Pages/player/components/GenreDialog.tsx
+++ b/resources/js/Pages/player/components/GenreDialog.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogOverlay, DialogTrigger } from "@radix-ui/react-dialog";
+import { motion, AnimatePresence } from "framer-motion";
+import { toast } from "react-toastify";
+
+export default function GenreDialog({ handler }: { handler: (param: string) => void }) {
+    const [open, setOpen] = useState(false);
+
+    const genres = ["Rock", "Hip-Hop", "Jazz", "Pop", "Classical", "Electronic"];
+
+    const selectGenre = (genre: string) => {
+        toast.success(`Selected genre: ${genre}`);
+        handler(genre);
+        setOpen(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+                <button className="bg-primary-500 hover:bg-primary-700 rounded-xl text-background p-2 flex items-center gap-2">
+                    Choose Genre
+                </button>
+            </DialogTrigger>
+
+            <AnimatePresence>
+                {open && (
+                    <>
+                        <DialogOverlay className="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm" />
+                        <DialogContent className="fixed inset-0 flex items-center justify-center">
+                            <motion.div
+                                className="relative bg-background-700 text-text-100 p-6 rounded-lg shadow-lg w-fit h-fit"
+                                initial={{ opacity: 0, scale: 0.95 }}
+                                animate={{ opacity: 1, scale: 1 }}
+                                exit={{ opacity: 0, scale: 0.95 }}
+                                transition={{ duration: 0.2 }}
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => setOpen(false)}
+                                    className="absolute top-2 right-2 text-text-100 hover:text-primary-300"
+                                >
+                                    ✕
+                                </button>
+                                <h2 className="text-xl font-bold mb-4">Select a Genre</h2>
+                                <div className="flex flex-wrap gap-4">
+                                    {genres.map((genre) => (
+                                        <button
+                                            key={genre}
+                                            onClick={() => selectGenre(genre)}
+                                            className="bg-primary-500 hover:bg-primary-700 text-background font-bold py-2 px-4 rounded"
+                                        >
+                                            {genre}
+                                        </button>
+                                    ))}
+                                </div>
+                            </motion.div>
+                        </DialogContent>
+                    </>
+                )}
+            </AnimatePresence>
+        </Dialog>
+    );
+}

--- a/resources/js/Pages/player/player.tsx
+++ b/resources/js/Pages/player/player.tsx
@@ -10,6 +10,7 @@ import axios from 'axios';
 import { useForm } from "@inertiajs/react";
 import SpotifyWebPlayer from 'react-spotify-web-playback';
 import PrimaryButton from '@/Components/PrimaryButton';
+import GenreDialog from './components/GenreDialog';
 
 // Helper to format ms into mm:ss
 const formatMsToMinutesAndSeconds = (ms: number): string => {
@@ -82,6 +83,14 @@ export function Player({ auth }: { auth: PageProps['auth'] }) {
         });
     };
 
+    const getRandomTrackByGenre = (genre: string) => {
+        api.get(`/spotify/random/${genre}`).then(response => {
+            if (response.status === 200) {
+                setUris([response.data.url]);
+            }
+        });
+    };
+
     // The progress timeline and time display below is based on the currentTrack state.
     // With react-spotify-web-playback you can extract track details in the callback.
     // Here we assume that the SpotifyWebPlayer callback returns a state with isPlaying and track information.
@@ -115,7 +124,7 @@ export function Player({ auth }: { auth: PageProps['auth'] }) {
                     callback={handlePlayerCallback}
                     autoPlay={true}
                     components={{
-                        leftButton: <PrimaryButton onClick={() => getRandomTrack()}>Get random track</PrimaryButton>
+                        leftButton: <GenreDialog handler={getRandomTrackByGenre} />,
                     }}
                     styles={{
                         activeColor: '#888877',


### PR DESCRIPTION
This pull request introduces a new feature for selecting a genre and retrieving a random track based on the selected genre. The changes involve updating the Spotify controller, adding a new component for genre selection, and modifying the player component to integrate the new feature.

### New Feature: Genre Selection and Random Track Retrieval

* [`resources/js/Pages/player/components/GenreDialog.tsx`](diffhunk://#diff-6117de9074bbd4bad9a77fc1a01affd863077eca86445a342dc41e44adaaf6f7R1-R63): Added a new `GenreDialog` component that allows users to select a genre from a list and triggers a handler function with the selected genre. This component uses `@radix-ui/react-dialog` for the dialog and `framer-motion` for animations.

* [`resources/js/Pages/player/player.tsx`](diffhunk://#diff-86463fea50b4683e5e96015ead0097077410a821f9f4f4fd94583fdd58a53592R13): Imported the new `GenreDialog` component and added a `getRandomTrackByGenre` function that fetches a random track based on the selected genre. The player component was updated to use `GenreDialog` for the left button, replacing the previous "Get random track" button. [[1]](diffhunk://#diff-86463fea50b4683e5e96015ead0097077410a821f9f4f4fd94583fdd58a53592R13) [[2]](diffhunk://#diff-86463fea50b4683e5e96015ead0097077410a821f9f4f4fd94583fdd58a53592R86-R93) [[3]](diffhunk://#diff-86463fea50b4683e5e96015ead0097077410a821f9f4f4fd94583fdd58a53592L118-R127)

### Backend Update

* [`app/Http/Controllers/SpotifyController.php`](diffhunk://#diff-262a8cbf10d16bc5bbf79870e09525c67788fec0b13905dbeaf2a70f8fc8339dL153-R153): Modified the `randomWithGenre` function to return the track's `uri` instead of the external Spotify URL.